### PR TITLE
Add missing pipe in sampled data message.

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -59,7 +59,7 @@ class Statsd
       if sample_rate < 1
         data.each do |d|
           if rand <= sample_rate
-            sampled_data << "#{d}@#{sample_rate}"
+            sampled_data << "#{d}|@#{sample_rate}"
           end
         end
         data = sampled_data

--- a/test/statsd_test.rb
+++ b/test/statsd_test.rb
@@ -17,7 +17,7 @@ class StatsdTest < Test::Unit::TestCase
 
     should "log when sampled" do
       fake_rand(0.09)
-      expected_send('test.stat:23|ms@0.1')
+      expected_send('test.stat:23|ms|@0.1')
       Statsd.timing('test.stat', 23, 0.1)
     end
 
@@ -45,7 +45,7 @@ class StatsdTest < Test::Unit::TestCase
 
     should "log when sampled" do
       fake_rand(0.09)
-      expected_send('test.stat:1|c@0.1')
+      expected_send('test.stat:1|c|@0.1')
       Statsd.increment('test.stat', 0.1)
     end
 
@@ -66,7 +66,7 @@ class StatsdTest < Test::Unit::TestCase
 
     should "log when sampled" do
       fake_rand(0.09)
-      expected_send('test.stat:-1|c@0.1')
+      expected_send('test.stat:-1|c|@0.1')
       Statsd.decrement('test.stat', 0.1)
     end
 
@@ -87,7 +87,7 @@ class StatsdTest < Test::Unit::TestCase
 
     should "log when sampled" do
       fake_rand(0.09)
-      expected_send('test.stat:1337|g@0.1')
+      expected_send('test.stat:1337|g|@0.1')
       Statsd.gauge('test.stat', 1337, 0.1)
     end
 


### PR DESCRIPTION
According to the statsd documentation, sampled data should be formatted in the following way
(please note the pipe added between the units and the sample rate):

gorets:1|c|@0.1

https://github.com/etsy/statsd#sampling
